### PR TITLE
BAH-4373 | Add. Support for using the Study Instance UID from ORM Order Message

### DIFF
--- a/Pacs_Simulator/src/main/java/org/bahmni/pacssimulator/DicomFileGenerator.java
+++ b/Pacs_Simulator/src/main/java/org/bahmni/pacssimulator/DicomFileGenerator.java
@@ -55,7 +55,7 @@ public class DicomFileGenerator {
         DicomFile dicomFile = new DicomFile(dicomFilePath);
         File file = null;
         try {
-            file = dicomFile.generateFor(patientId, givenName, familyName, accessionNumber);
+            file = dicomFile.generateFor(patientId, givenName, familyName, accessionNumber, null);
         } catch (URISyntaxException e) {
             e.printStackTrace();
         } catch (IOException e) {

--- a/Pacs_Simulator/src/main/java/org/bahmni/pacssimulator/HL7Utils.java
+++ b/Pacs_Simulator/src/main/java/org/bahmni/pacssimulator/HL7Utils.java
@@ -18,6 +18,7 @@ import ca.uhn.hl7v2.*;
 import ca.uhn.hl7v2.model.*;
 import ca.uhn.hl7v2.model.v25.message.*;
 import ca.uhn.hl7v2.model.v25.segment.*;
+import ca.uhn.hl7v2.util.Terser;
 
 import java.text.*;
 import java.util.*;
@@ -65,6 +66,20 @@ public class HL7Utils {
         ack.getMSA().getTextMessage().setValue(errorMessage);
 
         return ack;
+    }
+
+    public static String getStudyInstanceUID(ORM_O01 ormO01Message) {
+        Terser terser = new Terser(ormO01Message);
+        try {
+            String studyUID = terser.get("/ORDER/ORDER_DETAIL/ZDS-1");
+            System.out.printf("Retrieved STUDY UID: %s from HL7 Message%n", studyUID);
+            return studyUID;
+        } catch (Exception e) {
+            System.out.println("Unable to retrieve study instance UID from message");
+            System.out.println(e.getMessage());
+        }
+
+        return null;
     }
 
 }


### PR DESCRIPTION
This PR updates the DICOM File Generator to use the Study Instance UID from HL7 ORM_O01 message, if the id is passed as part of ZDS segment. 

JIRA: https://bahmni.atlassian.net/browse/BAH-4373